### PR TITLE
If setuptools is importable, don't force use of 'distribute'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,11 @@
 import os
 import sys
 
-from distribute_setup import use_setuptools
-use_setuptools()
+try:
+    import setuptools
+except ImportError:
+    from distribute_setup import use_setuptools
+    use_setuptools()
 from setuptools import setup, Extension
 
 if not hasattr(sys, "hexversion") or sys.hexversion < 0x02040000:


### PR DESCRIPTION
Allows use of post-merge setuptools 0.7.
