### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 *.zip
 *.egg
 *.egg-info/
+.tox/
 build/
 dist/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py25, py26, py27, py33
+
+[testenv]
+setenv =
+    TESTDB=travis.cnf
+commands =
+    nosetests {posargs:-w tests -v}
+deps =
+    nose

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,5 @@ setenv =
 commands =
     nosetests {posargs:-w tests -v}
 deps =
+    ipdb
     nose


### PR DESCRIPTION
[Tox](http://tox.testrun.org/) is a tool that lets you easily test across multiple Python versions locally (i.e.: you don't have to push to GitHub to test like you do with Travis CI, which I also like).

I think this would be a good thing to have when adding Python 3 support.
