### PR TITLE
Fix cut off SQL query when its contained `))`

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -26,7 +26,7 @@ restr = r"""
                 (?:
                         (?:\(
                             # ( - editor hightlighting helper
-                            [^)]*
+                            .*
                         \))
                     |
                         '


### PR DESCRIPTION
Edit insert_values regexp. Fixes issue #33.
This is quick solution. Regexp may be does not perform initially planned actions.
Need check carefuly.
