### PR TITLE
Fix the conversion of list or tuple args to SQL.

### DIFF
--- a/MySQLdb/converters.py
+++ b/MySQLdb/converters.py
@@ -129,13 +129,16 @@ def char_array(s):
 def array2Str(o, d):
     return Thing2Literal(o.tostring(), d)
 
+def quote_tuple(t, d):
+    return "(%s)" % (','.join(escape_sequence(t, d)))
+
 conversions = {
     IntType: Thing2Str,
     LongType: Long2Int,
     FloatType: Float2Str,
     NoneType: None2NULL,
-    TupleType: escape_sequence,
-    ListType: escape_sequence,
+    TupleType: quote_tuple,
+    ListType: quote_tuple,
     DictType: escape_dict,
     InstanceType: Instance2Str,
     ArrayType: array2Str,

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -240,7 +240,13 @@ class BaseCursor(object):
         e = m.end(1)
         qv = m.group(1)
         try:
-            q = [ qv % db.literal(a) for a in args ]
+            q = []
+            for a in args:
+                if isinstance(a, dict):
+                    q.append(qv % dict((key, db.literal(item))
+                                       for key, item in a.iteritems()))
+                else:
+                    q.append(qv % tuple([db.literal(item) for item in a]))
         except TypeError, msg:
             if msg.args[0] in ("not enough arguments for format string",
                                "not all arguments converted"):

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -180,7 +180,10 @@ class BaseCursor(object):
         if isinstance(query, unicode):
             query = query.encode(db.unicode_literal.charset)
         if args is not None:
-            query = query % db.literal(args)
+            if isinstance(args, dict):
+                query = query % {key: db.literal(item) for key, item in args.iteritems()}
+            else:
+                query = query % tuple([db.literal(item) for item in args])
         try:
             r = None
             r = self._query(query)

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -181,7 +181,8 @@ class BaseCursor(object):
             query = query.encode(db.unicode_literal.charset)
         if args is not None:
             if isinstance(args, dict):
-                query = query % {key: db.literal(item) for key, item in args.iteritems()}
+                query = query % dict((key, db.literal(item))
+                                     for key, item in args.iteritems())
             else:
                 query = query % tuple([db.literal(item) for item in args])
         try:


### PR DESCRIPTION
When making a query with an argument which is a one element list (or tuple) for an IN clause, the generated SQL is not valid and the query fails.

Examples:
- `c.execute("SELECT * from T WHERE id IN %s", [[1, 2, 3]])`  --> `SELECT * from T WHERE id IN ('1', '2', '3')` **OK**
- `c.execute("SELECT * from T WHERE id IN %s", [[1]])` --> `SELECT * from T WHERE id IN ('1',)` **Fail**
- `c.execute("SELECT * from T WHERE id IN %(list)s", {'list': [1, 2, 3]})` --> `SELECT * from T WHERE id IN ('1', '2', '3')` **OK**
- `c.execute("SELECT * from T WHERE id IN %(list)s", {'list': [1]})` --> `SELECT * from T WHERE id IN ('1',)` **Fail**

In fact the list is converted as the string representation of a python tuple, with a final coma for one element tuples, and then breaks the SQL syntax.
