### PR TITLE
setup_windows: Added extra_link_args + win 32b platform support

### DIFF
--- a/setup_windows.py
+++ b/setup_windows.py
@@ -6,6 +6,8 @@ def get_config():
     metadata, options = get_metadata_and_options()
 
     connector = options["connector"]
+    if 'PROGRAMFILES(X86)' not in os.environ:
+        connector = connector.replace(' (x86)', '')
 
     extra_objects = []
 
@@ -18,6 +20,7 @@ def get_config():
     libraries = [ 'kernel32', 'advapi32', 'wsock32', client ]
     include_dirs = [ os.path.join(connector, r'include') ]
     extra_compile_args = [ '/Zl' ]
+    extra_link_args=['/MANIFEST']
     
     name = "MySQL-python"
     if enabled(options, 'embedded'):
@@ -35,6 +38,7 @@ def get_config():
         library_dirs = library_dirs,
         libraries = libraries,
         extra_compile_args = extra_compile_args,
+        extra_link_args = extra_link_args,
         include_dirs = include_dirs,
         extra_objects = extra_objects,
         define_macros = define_macros,

--- a/site.cfg
+++ b/site.cfg
@@ -14,4 +14,5 @@ static = False
 
 # http://stackoverflow.com/questions/1972259/mysql-python-install-problem-using-virtualenv-windows-pip
 # Windows connector libs for MySQL. You need a 32-bit connector for your 32-bit Python build.
+# on 32 bit windows, 'Program Files (x86)' is replaced by 'Program Files' 
 connector = C:\Program Files (x86)\MySQL\MySQL Connector C 6.0.2


### PR DESCRIPTION
See issue #54 about setup_windows.py

Added extra_link_args (see http://bugs.python.org/issue4431)
Added 32-bit platform detection to strip the ' (x86)' bit from Program Files directory name.
