### PR TITLE
tox.ini: Remove ipdb

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,4 @@ setenv =
 commands =
     nosetests {posargs:-w tests -v}
 deps =
-    ipdb
     nose


### PR DESCRIPTION
It makes tests take longer to install deps and now causes this error on Python < 2.7, because of IPython 2.0.0 requiring 2.7:

```
ERROR: IPython requires Python Version 2.7 or above.
```

Cc: @haypo, @okin, @methane
