### PR TITLE
Remove MySQLdb/release.py from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .tox/
 build/
 dist/
+MySQLdb/release.py

--- a/MySQLdb/release.py
+++ b/MySQLdb/release.py
@@ -1,4 +1,0 @@
-
-__author__ = "Andy Dustman <farcepest@gmail.com>"
-version_info = (1,2,4,'final',1)
-__version__ = "1.2.4"


### PR DESCRIPTION
because it's generated from `metadata.cfg`

and because I keep getting annoying diffs because of newline differences
-- e.g.:

```
$ git diff
diff --git a/MySQLdb/release.py b/MySQLdb/release.py
index 5c30a6c..4ce9412 100644
--- a/MySQLdb/release.py
+++ b/MySQLdb/release.py
@@ -1,4 +1,4 @@
-
-__author__ = "Andy Dustman <farcepest@gmail.com>"
-version_info = (1,2,4,'final',1)
-__version__ = "1.2.4"
+
+__author__ = "Andy Dustman <farcepest@gmail.com>"
+version_info = (1,2,4,'final',1)
+__version__ = "1.2.4"
```

Cc: @haypo, @okin, @methane
