### PR TITLE
Support Python 2.7, 3.3, 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ TODO
 ----
 
 * A bugfix 1.2.4 release
-* A 1.3.0 release that will support Python 2.7-3.3
+* A 1.3.0 release that will support Python 2.7-3.4
 * The 2.0 version is being renamed [moist][] and is heavily refactored.
 
 Projects

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py25, py26, py27, py33
+envlist = py27, py33, py34
 
 [testenv]
 setenv =


### PR DESCRIPTION
These are reasonably modern versions of Python that I think are worth supporting for the planned 1.3.0 release.

Cc: @haypo, @okin, @methane
