### PR TITLE
Make SafeConfigParser import work on py3

### DIFF
--- a/setup_posix.py
+++ b/setup_posix.py
@@ -1,5 +1,5 @@
 import os, sys
-from ConfigParser import SafeConfigParser
+from setup_common import SafeConfigParser
 
 # This dequote() business is required for some older versions
 # of mysql_config


### PR DESCRIPTION
Easy one line change to make `SafeConfigParser` import work in both Python 2 and Python 3.

Cc: @haypo, @okin, @methane
