### PR TITLE
Some Python 3 C-API fixes.

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -2997,6 +2997,8 @@ init_mysql(void)
 	module = PyModule_Create(&_mysqlmodule);
 	if (!module) return module; /* this really should never happen */
 #else
+	_mysql_ConnectionObject_Type.tp_free = _PyObject_GC_Del;
+	_mysql_ResultObject_Type.tp_free = _PyObject_GC_Del;
 	module = Py_InitModule4("_mysql", _mysql_methods, _mysql___doc__,
 				(PyObject *)NULL, PYTHON_API_VERSION);
 	if (!module) return; /* this really should never happen */

--- a/_mysql.c
+++ b/_mysql.c
@@ -2791,7 +2791,7 @@ PyTypeObject _mysql_ResultObject_Type = {
 	0, /* (hashfunc) tp_hash */
 	0, /* (ternaryfunc) tp_call */
 	0, /* (reprfunc) tp_str */
-	0, /* tp_getattro */
+	(getattrofunc)PyObject_GenericGetAttr, /* tp_getattro */
 	(setattrofunc)_mysql_ResultObject_setattro, /* tp_setattr */
 	
 	/* Functions to access object as input/output buffer */

--- a/_mysql.c
+++ b/_mysql.c
@@ -47,9 +47,6 @@ PERFORMANCE OF THIS SOFTWARE.
 #include "mysqld_error.h"
 #include "errmsg.h"
 
-#define MyTuple_Resize(t,n,d) _PyTuple_Resize(t, n)
-#define MyMember(a,b,c,d,e) {a,b,c,d,e}
-#define MyMemberlist(x) struct PyMemberDef x
 #define MyAlloc(s,t) (s *) t.tp_alloc(&t,0)
 #ifdef IS_PY3K
 # define MyFree(o) Py_TYPE(o)->tp_free((PyObject*)o)
@@ -1505,7 +1502,7 @@ _mysql__fetch_row(
 			goto error;
 		}
 		if (!row) {
-			if (MyTuple_Resize(r, i, 0) == -1) goto error;
+			if (_PyTuple_Resize(r, i) == -1) goto error;
 			break;
 		}
 		v = convert_row(self, row);
@@ -1568,7 +1565,7 @@ _mysql_ResultObject_fetch_row(
 				if (rowsadded == -1) goto error;
 				skiprows += rowsadded;
 				if (rowsadded < maxrows) break;
-				if (MyTuple_Resize(&r, skiprows+maxrows, 0) == -1)
+				if (_PyTuple_Resize(&r, skiprows+maxrows) == -1)
 				        goto error;
 			}
 		} else {
@@ -2509,42 +2506,42 @@ static PyMethodDef _mysql_ConnectionObject_methods[] = {
 	{NULL,              NULL} /* sentinel */
 };
 
-static MyMemberlist(_mysql_ConnectionObject_memberlist)[] = {
-	MyMember(
+static struct PyMemberDef _mysql_ConnectionObject_memberlist[] = {
+	{
 		"open",
 		T_INT,
 		offsetof(_mysql_ConnectionObject,open),
 		READONLY,
 		"True if connection is open"
-		),
-	MyMember(
+	},
+	{
 		"converter",
 		T_OBJECT,
 		offsetof(_mysql_ConnectionObject,converter),
 		0,
 		"Type conversion mapping"
-		),
-	MyMember(
+	},
+	{
 		"server_capabilities",
 		T_UINT,
 		offsetof(_mysql_ConnectionObject,connection.server_capabilities),
 		READONLY,
 		"Capabilites of server; consult MySQLdb.constants.CLIENT"
-		),
-	MyMember(
-		 "port",
-		 T_UINT,
-		 offsetof(_mysql_ConnectionObject,connection.port),
-		 READONLY,
-		 "TCP/IP port of the server connection"
-		 ),
-	MyMember(
-		 "client_flag",
-		 T_UINT,
-		 READONLY,
-		 offsetof(_mysql_ConnectionObject,connection.client_flag),
-		 "Client flags; refer to MySQLdb.constants.CLIENT"
-		 ),
+	},
+	{
+		"port",
+		T_UINT,
+		offsetof(_mysql_ConnectionObject,connection.port),
+		READONLY,
+		"TCP/IP port of the server connection"
+	},
+	{
+		"client_flag",
+		T_UINT,
+		READONLY,
+		offsetof(_mysql_ConnectionObject,connection.client_flag),
+		"Client flags; refer to MySQLdb.constants.CLIENT"
+	},
 	{NULL} /* Sentinel */
 };
 
@@ -2600,14 +2597,14 @@ static PyMethodDef _mysql_ResultObject_methods[] = {
 	{NULL,              NULL} /* sentinel */
 };
 
-static MyMemberlist(_mysql_ResultObject_memberlist)[] = {
-	MyMember(
+static struct PyMemberDef _mysql_ResultObject_memberlist[] = {
+	{
 		"converter",
 		T_OBJECT,
 		offsetof(_mysql_ResultObject,converter),
 		READONLY,
 		"Type conversion mapping"
-		),
+	},
 	{NULL} /* Sentinel */
 };
 
@@ -2712,7 +2709,7 @@ PyTypeObject _mysql_ConnectionObject_Type = {
 	
 	/* Attribute descriptor and subclassing stuff */
 	(struct PyMethodDef *)_mysql_ConnectionObject_methods, /* tp_methods */
-	(MyMemberlist(*))_mysql_ConnectionObject_memberlist, /* tp_members */
+	(struct PyMemberDef *)_mysql_ConnectionObject_memberlist, /* tp_members */
 	0, /* (struct getsetlist *) tp_getset; */
 	0, /* (struct _typeobject *) tp_base; */
 	0, /* (PyObject *) tp_dict */
@@ -2785,7 +2782,7 @@ PyTypeObject _mysql_ResultObject_Type = {
 	
 	/* Attribute descriptor and subclassing stuff */
 	(struct PyMethodDef *) _mysql_ResultObject_methods, /* tp_methods */
-	(MyMemberlist(*)) _mysql_ResultObject_memberlist, /*tp_members */
+	(struct PyMemberDef *) _mysql_ResultObject_memberlist, /*tp_members */
 	0, /* (struct getsetlist *) tp_getset; */
 	0, /* (struct _typeobject *) tp_base; */
 	0, /* (PyObject *) tp_dict */

--- a/_mysql.c
+++ b/_mysql.c
@@ -60,7 +60,7 @@ PERFORMANCE OF THIS SOFTWARE.
 # define MyMemberlist(x) struct PyMemberDef x
 # define MyAlloc(s,t) (s *) t.tp_alloc(&t,0)
 #ifdef IS_PY3K
-# define MyFree(o) PyObject_Del(o)
+# define MyFree(o) Py_TYPE(o)->tp_free((PyObject*)o)
 #else
 # define MyFree(ob) ob->ob_type->tp_free((PyObject *)ob)
 #endif
@@ -924,7 +924,7 @@ _mysql_ConnectionObject_commit(
 	if (err) return _mysql_Exception(self);
 	Py_INCREF(Py_None);
 	return Py_None;
-}		
+}
 
 static char _mysql_ConnectionObject_rollback__doc__[] =
 "Rolls backs the current transaction\n\
@@ -2985,14 +2985,8 @@ init_mysql(void)
 #if PY_VERSION_HEX >= 0x02020000
 	_mysql_ConnectionObject_Type.tp_alloc = PyType_GenericAlloc;
 	_mysql_ConnectionObject_Type.tp_new = PyType_GenericNew;
-#ifndef IS_PY3K
-	_mysql_ConnectionObject_Type.tp_free = _PyObject_GC_Del;
-#endif
 	_mysql_ResultObject_Type.tp_alloc = PyType_GenericAlloc;
 	_mysql_ResultObject_Type.tp_new = PyType_GenericNew;
-#ifndef IS_PY3K
-	_mysql_ResultObject_Type.tp_free = _PyObject_GC_Del;
-#endif
 #endif
 #ifdef IS_PY3K
 	if (PyType_Ready(&_mysql_ConnectionObject_Type) < 0)


### PR DESCRIPTION
tp_getattr and tp_setattr are deprecated.
Use tp_getattro and tp_setattro instead.

Fix wrong deallocation macro.

Remove some macros for very old Python (<2.2)
