### PR TITLE
Fix wrong sign with negative zero hour timediff. Fixes #63

### DIFF
--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -71,13 +71,13 @@ def TimeDelta_or_None(s):
         else:
             ms = 0
         if h[0] == '-':
-            isNegative = True
+            negative = True
         else:
-            isNegative = False
-        h, m, s, ms = int(h), int(m), int(s), int(ms)
-        td = timedelta(hours=abs(h), minutes=m, seconds=s,
+            negative = False
+        h, m, s, ms = abs(int(h)), int(m), int(s), int(ms)
+        td = timedelta(hours=h, minutes=m, seconds=s,
                        microseconds=ms)
-        if isNegative:
+        if negative:
             return -td
         else:
             return td

--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -70,10 +70,14 @@ def TimeDelta_or_None(s):
             ms = ms.ljust(6, '0')
         else:
             ms = 0
+        if h[0] == '-':
+            isNegative = True
+        else:
+            isNegative = False
         h, m, s, ms = int(h), int(m), int(s), int(ms)
         td = timedelta(hours=abs(h), minutes=m, seconds=s,
                        microseconds=ms)
-        if h < 0:
+        if isNegative:
             return -td
         else:
             return td


### PR DESCRIPTION
Checking timediff sign by dash in first character of hour variable instead of comparison with zero.
