### PR TITLE
fix string replacement support for sql

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -183,6 +183,8 @@ class BaseCursor(object):
             if isinstance(args, dict):
                 query = query % dict((key, db.literal(item))
                                      for key, item in args.iteritems())
+            elif isinstance(args, str) or isinstance(args, unicode):
+                query = query % db.literal(args)
             else:
                 query = query % tuple([db.literal(item) for item in args])
         try:


### PR DESCRIPTION
string replacement was broken by
https://github.com/farcepest/MySQLdb1/commit/87d1145c0d6ee4f5a8ecf6d5c62d2479b9cf27ea

This fix is to bring the string replacement support back:
  sql = "SELECT \* FROM table_name WHERE column = %s"
  cursor.execute(sql, 'passed_variable')
