### PR TITLE
Fix building on Windows for latest MySQL Connector C 6.1

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -38,11 +38,7 @@ PERFORMANCE OF THIS SOFTWARE.
 #endif
 #include "pymemcompat.h"
 #include "structmember.h"
-#if defined(MS_WINDOWS)
-#include <config-win.h>
-#else
 #include "my_config.h"
-#endif
 #include "mysql.h"
 #include "mysqld_error.h"
 #include "errmsg.h"

--- a/setup_windows.py
+++ b/setup_windows.py
@@ -14,7 +14,7 @@ def get_config():
     else:
         client = "mysqlclient"
 
-    library_dirs = [ os.path.join(connector, r'lib\opt') ]
+    library_dirs = [ os.path.join(connector, r'lib\vs11') ]
     libraries = [ 'kernel32', 'advapi32', 'wsock32', client ]
     include_dirs = [ os.path.join(connector, r'include') ]
     extra_compile_args = [ '/Zl' ]

--- a/site.cfg
+++ b/site.cfg
@@ -14,4 +14,4 @@ static = False
 
 # http://stackoverflow.com/questions/1972259/mysql-python-install-problem-using-virtualenv-windows-pip
 # Windows connector libs for MySQL. You need a 32-bit connector for your 32-bit Python build.
-connector = C:\Program Files (x86)\MySQL\MySQL Connector C 6.0.2
+connector = C:\Program Files (x86)\MySQL\MySQL Connector C 6.1


### PR DESCRIPTION
When using latest MySQL Connector C 6.1, there's no such `config-win.h`, but there's `my_config.h`. And also there aren't `opt` dir anymore. With this PR it builds fine.
