### PR TITLE
Encode message passed to warn

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -114,10 +114,10 @@ class BaseCursor(object):
                 for w in warnings:
                     self.messages.append((self.Warning, w))
                 for w in warnings:
-                    warn(w[-1], self.Warning, 3)
+                    warn(w[-1].encode('utf-8'), self.Warning, 3)
             elif self._info:
                 self.messages.append((self.Warning, self._info))
-                warn(self._info, self.Warning, 3)
+                warn(self._info.encode('utf-8'), self.Warning, 3)
 
     def nextset(self):
         """Advance to the next result set.


### PR DESCRIPTION
Funcion warn expects first argument to be str only. If unicode containing some non-ascii symbols is passed, exception is raised.

    >>> from warnings import warn
    >>> warn(u'řčš')
    Traceback (most recent call last):
      File "<input>", line 1, in <module>
      File "/usr/lib/python2.7/warnings.py", line 29, in _show_warning
        file.write(formatwarning(message, category, filename, lineno, line))
      File "/usr/lib/python2.7/warnings.py", line 38, in formatwarning
        s =  "%s:%s: %s: %s\n" % (filename, lineno, category.__name__, message)
    UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)

    >>> warn(u'řčš'.encode('utf-8'))
    /usr/local/bin/bpython:2: UserWarning: řčš

Plain ascii strings are not affected by this fix:

    >>> warn('aaa'.encode('utf-8'))
    /usr/local/bin/bpython:2: UserWarning: aaa