### PR TITLE
Py2/3 Compatible Imports for ConfigParser

### DIFF
--- a/setup_posix.py
+++ b/setup_posix.py
@@ -1,5 +1,8 @@
 import os, sys
-from ConfigParser import SafeConfigParser
+if sys.version_info.major >= 3:
+    from configparser import SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
 
 # This dequote() business is required for some older versions
 # of mysql_config


### PR DESCRIPTION
Py3 renamed 'ConfigParser' to 'configparser'.  This fails on Py3 setup, because it tries to import 'ConfigParser' and not 'configparser'.  Otherwise it should work identically.

Note that I got here from the PyPI page.  Unless you upload a Python2 only wheel and *not* a Python3 wheel, it's going to be able to install from the source you uploaded, which is not yet Python3 compatible.  However, this change *should* fix the Py3 problem.