### PR TITLE
Fix ConfigParser import for Python3 in setup_posix.py

### DIFF
--- a/setup_posix.py
+++ b/setup_posix.py
@@ -1,5 +1,10 @@
 import os, sys
-from ConfigParser import SafeConfigParser
+try:
+    # Python 2.x
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    # Python 3.x
+    from configparser import ConfigParser as SafeConfigParser
 
 # This dequote() business is required for some older versions
 # of mysql_config


### PR DESCRIPTION
Otherwise, this module will raise ModuleNotFound errors on import.

I found out about this issue from a comment in a Stackoverflow thread: https://stackoverflow.com/questions/35641893/best-way-for-python-to-interface-with-mysql/35842375?noredirect=1#comment84048239_35842375.