### PR TITLE
In python 3.x ConfigParser changed to configparser

### DIFF
--- a/setup_posix.py
+++ b/setup_posix.py
@@ -1,5 +1,10 @@
 import os, sys
-from ConfigParser import SafeConfigParser
+try:
+    # Python 2.x
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    # Python 3.x
+    from configparser import ConfigParser as SafeConfigParser
 
 # This dequote() business is required for some older versions
 # of mysql_config


### PR DESCRIPTION
Added try except block to support python 2.x and python 3.x